### PR TITLE
[REFINE] add tambah produk button to informasi page and delete inform…

### DIFF
--- a/src/app/(withNavbar)/informasi/page.tsx
+++ b/src/app/(withNavbar)/informasi/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import HeaderProduk from '@/src/components/HeaderProduk';
 import config from '@/src/config';
 import { useAuth } from '@/contexts/AuthContext';
+import { PlusIcon } from '@/public/icons/PlusIcon';
 
 interface TopSellingProduct {
   id: number;
@@ -181,7 +182,7 @@ const SemuaBarangPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 pb-20">
+    <div className="relative min-h-screen">
       <HeaderProduk />
       <main className="container mx-auto px-4 py-6 space-y-6">
         
@@ -389,6 +390,14 @@ const SemuaBarangPage: React.FC = () => {
         </section>
 
       </main>
+
+      {/* Floating Add Product Button - updated to match Semua Barang page styling */}
+      <button
+        className="bg-primary-indigo rounded-full w-fit fixed bottom-4 right-4 sm:right-[calc(50%-(420px/2)+1rem)] p-4 mb-24"
+        onClick={() => router.push('/tambahProduk')}
+      >
+        <PlusIcon />
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
Gue udah update page informasi produk dengan perubahan berikut:

### Yang gue ubah:
1. **Ilangin background color abu-abu** (bg-gray-100) di container utama
   - Sebelumnya pake class `bg-gray-100` di parent div
   - Sekarang gue ganti jadi clean look pake background default

2. **Tambahin floating button dengan icon plus**
   - Gue pasang button circle fixed di bagian bawah kanan page
   - Button ini buat navigasi ke halaman tambah produk

### Kode yang gue ubah:

1. **Hapus background color:**
```diff
- <div className="min-h-screen bg-gray-100 pb-20">
+ <div className="relative min-h-screen">
```

2. **Tambahin floating button:**
```jsx
{/* Floating Add Product Button - updated to match Semua Barang page styling */}
<button
  className="bg-primary-indigo rounded-full w-fit fixed bottom-4 right-4 sm:right-[calc(50%-(420px/2)+1rem)] p-4 mb-24"
  onClick={() => router.push('/tambahProduk')}
>
  <PlusIcon />
</button>
```

3. **Import komponen PlusIcon yang diperlukan:**
```jsx
import { PlusIcon } from '@/public/icons/PlusIcon';
```

Biar kebayang ini before and afternya:

Before:
![Screenshot 2025-05-03 200735](https://github.com/user-attachments/assets/ea3bebff-a625-4bf2-b29f-351575aadcd7)

After:
![Screenshot 2025-05-03 201841](https://github.com/user-attachments/assets/3b2acf3c-4244-4038-8670-fcfb6f0bf806)

Note: PR ini gak ada perubahan logic, purely UI updates aja.