### PR TITLE
Fix arus kas summary bug

### DIFF
--- a/src/app/(withNavbar)/report/page.tsx
+++ b/src/app/(withNavbar)/report/page.tsx
@@ -359,6 +359,12 @@ const ReportPage = () => {
           } else {
             const data : ArusKasReportResponse = await response.json();
             setArusKasTransactions(data.transactions || []);
+
+            setSummary(prev => ({
+              ...prev,
+              totalPemasukan: Number(data.total_inflow) || 0,
+              totalPengeluaran: Number(data.total_outflow) || 0
+            }));
           }
         }    
       } catch (error) {


### PR DESCRIPTION
What i fix (assume we have recorded transaction):
 - When the filter date is set to a range with no transactions and we navigate to another page, the summary data incorrectly shows 0 for both 'Total Kas Masuk' and 'Total Kas Keluar'. The correct data is only displayed again after the filter date is changed.