### PR TITLE
Ubah Page Transaksi Menjadi Per Bulan

### DIFF
--- a/src/app/(withNavbar)/transaksi/module-elements/TransactionSummary.tsx
+++ b/src/app/(withNavbar)/transaksi/module-elements/TransactionSummary.tsx
@@ -16,7 +16,12 @@ interface SummaryData {
 	amount: number;
 }
 
-export const TransactionSummary = () => {
+interface TransactionSummaryProps {
+  selectedMonth: number;
+  selectedYear: number;
+}
+
+export const TransactionSummary = ({ selectedMonth, selectedYear }: TransactionSummaryProps) => {
 	const [summaryData, setSummaryData] = useState<SummaryData | null>(null)
 	const [loading, setLoading] = useState(true)
 	const [error, setError] = useState<string | null>(null)
@@ -34,7 +39,7 @@ export const TransactionSummary = () => {
 			setError(null);
 
 			try {
-				const response = await fetch(`${config.apiUrl}/transaksi/summary/monthly`, {
+				const response = await fetch(`${config.apiUrl}/transaksi/summary/monthly?month=${selectedMonth}&year=${selectedYear}`, {
 					headers: {
 						Authorization: `Bearer ${accessToken}`,
 					},
@@ -55,7 +60,7 @@ export const TransactionSummary = () => {
 		}
 
 		fetchSummaryData()
-	}, [accessToken])
+	}, [accessToken, selectedMonth, selectedYear])
 
 	if (loading) {
 		return <div className="flex flex-col gap-2">
@@ -76,6 +81,15 @@ export const TransactionSummary = () => {
 	const formatCurrency = (amount: number) => {
 		return amount.toLocaleString("id-ID");
 	};
+  
+  // Get month name in Indonesian
+  const getMonthName = (month: number) => {
+    const monthNames = [
+      "Januari", "Februari", "Maret", "April", "Mei", "Juni",
+      "Juli", "Agustus", "September", "Oktober", "November", "Desember"
+    ];
+    return monthNames[month - 1];
+  };
 
 	return (
 		<div className="flex flex-col gap-2">

--- a/src/app/(withNavbar)/transaksi/page.tsx
+++ b/src/app/(withNavbar)/transaksi/page.tsx
@@ -436,7 +436,7 @@ export default function TransactionMainPage() {
           </div>
         ) : transactions.length === 0 ? (
           <div className="py-10 text-center">
-            <p>No transactions found.</p>
+            <p>Tidak ada transaksi ditemukan</p>
           </div>
         ) : (
           transactions.map((transaction) => (


### PR DESCRIPTION
Gue udah nambahin filter bulan dan tahun di halaman transaksi untuk mempermudah tracking transaksi berdasarkan waktu. Jadi user bisa pilih bulan dan tahun yang mereka mau lihat. Super useful lah buat analisis bulanan.

## Yang gue ubah:
- Nambahin dropdown filter untuk bulan (Januari-Desember) yang default-nya ke bulan sekarang
- Nambahin dropdown filter tahun (5 tahun terakhir) yang default-nya ke tahun sekarang
- Update API call untuk fetch transaksi dengan parameter `month` dan `year`
- Update dependency di `useEffect` buat reload data tiap kali bulan/tahun berubah
- Pass `selectedMonth` dan `selectedYear` ke komponen `TransactionSummary` untuk konsistensi data

## How it works:
- User bisa klik dropdown bulan/tahun dan milih yang mereka mau
- Data transaksi dan summary langsung ke-update sesuai periode yang dipilih
- Semua fetching data udah consider bulan dan tahun yang dipilih user

**Before:**
![Screenshot 2025-05-07 154529](https://github.com/user-attachments/assets/5951487d-d61d-40b7-8a9d-f36d9395bba6)

**After:**
![Screenshot 2025-05-07 170812](https://github.com/user-attachments/assets/81d4b42a-d37f-4dc8-8cf4-b7814544c8dc)

![Screenshot 2025-05-07 170819](https://github.com/user-attachments/assets/9ab2ea7e-d1e4-4ece-bcb7-151f704612cb)

Mohon reviewnya guys apa perlu ada yang ditambah atau masih salah?